### PR TITLE
feat(mux-video-ads): ads implementation with data

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-video-ads.html
+++ b/examples/vanilla-ts-esm/public/mux-video-ads.html
@@ -37,9 +37,27 @@
             </a>
         </div>
     </header>
-    <mux-video-ads src="https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
-        metadata-video-id="video-id-12345" metadata-video-title="Star Wars: Episode 3"
-        metadata-viewer-user-id="user-id-6789" stream-type="on-demand" prefer-playback="mse" controls playsinline muted
+    <!--
+      Description of attributes:
+      debug: Add/remove to enable/disable hls.js, mux-embed (mux data sdk), and elements debug logging.
+      metadata-*: values that will be sent to Mux Data for corresponding data views
+      prefer-playback: Add/remove to prefer e.g. MSE/hls.js even on playback environments that normally wouldn't
+        (e.g. on Mobile Safari to test Google IMA + MSE behaviors for that platform)
+      playsinline: Add/remove to test fullscreen vs. inline behaviors on mobile devices when using Google IMA with ad permutations and playback environments
+        (e.g. skippable ads on Mobile Safari)
+      autoplay: Add/remove to test Google IMA with autoplay enabled/disabled
+     -->
+    <mux-video-ads
+        debug
+        playback-id="a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M"
+        metadata-video-id="this-is-a-video--with-ads"
+        metadata-video-title="I AM TESTING ADS"
+        metadata-viewer-user-id="user-is-testing-ads"
+        prefer-playback="mse"
+        playsinline
+        controls
+        muted
+        autoplay
         adtagurl="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="></mux-video-ads>
 
     <a href="../">Browse Elements</a>

--- a/examples/vanilla-ts-esm/src/mux-video-ads.ts
+++ b/examples/vanilla-ts-esm/src/mux-video-ads.ts
@@ -1,1 +1,1 @@
-export * as MuxVideo from "mux-video-ads/dist/index.cjs";
+export * as MuxVideo from "@mux/mux-video-ads";

--- a/package-lock.json
+++ b/package-lock.json
@@ -4820,14 +4820,6 @@
       "resolved": "packages/mux-audio-react",
       "link": true
     },
-    "node_modules/@mux/mux-data-google-ima": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.7.tgz",
-      "integrity": "sha512-5uQ2VcYWH9lIEeC8KDHcd8BzfiNeOFeCAheBw8s6cVfgP0gj/7+m9HQ55Ji4F0ftW+krLOUXbtu3HQkVhH//yg==",
-      "dependencies": {
-        "mux-embed": "5.9.0"
-      }
-    },
     "node_modules/@mux/mux-elements-codemod": {
       "resolved": "packages/mux-elements-codemod",
       "link": true
@@ -30606,8 +30598,9 @@
       "name": "@mux/mux-video-ads",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-data-google-ima": "0.2.7",
-        "@mux/mux-video": "0.24.3",
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/mux-video": "0.24.4",
+        "@mux/playback-core": "0.28.4",
         "hls.js": "~1.5.19"
       },
       "devDependencies": {
@@ -31017,24 +31010,12 @@
         "node": ">=18"
       }
     },
-    "packages/mux-video-ads/node_modules/@mux/mux-video": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.24.3.tgz",
-      "integrity": "sha512-HM5oasXfmYVfmsTMv1lZIW/OkHEQMJwavrl1gI4p13bdlmmUu2CNARiTv/tYATJ9+NkYHlU3RsteHXx7tK7+vg==",
+    "packages/mux-video-ads/node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
       "dependencies": {
-        "@mux/playback-core": "0.28.3",
-        "castable-video": "~1.1.4",
-        "custom-media-element": "~1.4.2",
-        "media-tracks": "~0.3.2"
-      }
-    },
-    "packages/mux-video-ads/node_modules/@mux/playback-core": {
-      "version": "0.28.3",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.28.3.tgz",
-      "integrity": "sha512-QID2zp76szCTiXZp5LLYwDZV68HgflOoF10Vmp6P81FqKHonHVrQ0svNGqW6fMZLH2Ymf/Qc6kHSnwWTucgQqA==",
-      "dependencies": {
-        "hls.js": "~1.5.19",
-        "mux-embed": "^5.5.0"
+        "mux-embed": "5.9.0"
       }
     },
     "packages/mux-video-ads/node_modules/esbuild": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4820,6 +4820,14 @@
       "resolved": "packages/mux-audio-react",
       "link": true
     },
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.7.tgz",
+      "integrity": "sha512-5uQ2VcYWH9lIEeC8KDHcd8BzfiNeOFeCAheBw8s6cVfgP0gj/7+m9HQ55Ji4F0ftW+krLOUXbtu3HQkVhH//yg==",
+      "dependencies": {
+        "mux-embed": "5.9.0"
+      }
+    },
     "node_modules/@mux/mux-elements-codemod": {
       "resolved": "packages/mux-elements-codemod",
       "link": true
@@ -4842,6 +4850,10 @@
     },
     "node_modules/@mux/mux-video": {
       "resolved": "packages/mux-video",
+      "link": true
+    },
+    "node_modules/@mux/mux-video-ads": {
+      "resolved": "packages/mux-video-ads",
       "link": true
     },
     "node_modules/@mux/mux-video-react": {
@@ -6789,6 +6801,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/google_interactive_media_ads_types": {
+      "version": "1.20241219.0",
+      "resolved": "https://registry.npmjs.org/@types/google_interactive_media_ads_types/-/google_interactive_media_ads_types-1.20241219.0.tgz",
+      "integrity": "sha512-xH/4+wiD/vpvsHvssGvNWvhtM10869C6sUR4J1zRyRI4iGrg8IUbkSytqVYMvCVn8m241zT4Cij8LjBXkWrqHg==",
+      "dev": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -17495,10 +17513,9 @@
       "license": "MIT"
     },
     "node_modules/mux-embed": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.8.3.tgz",
-      "integrity": "sha512-cNI/5StDDc6R8hBuMI61QPUn0j4NkPhs+lj8IQ1s75HIUnJJEgox8EtmH97G5itB8ZZIzDTw8Ycm77VP1km22A==",
-      "license": "MIT"
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w=="
     },
     "node_modules/nanocolors": {
       "version": "0.2.13",
@@ -30583,6 +30600,481 @@
         "replace": "^1.2.2",
         "shx": "^0.4.0",
         "typescript": "^5.8.2"
+      }
+    },
+    "packages/mux-video-ads": {
+      "name": "@mux/mux-video-ads",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-data-google-ima": "0.2.7",
+        "@mux/mux-video": "0.24.3",
+        "hls.js": "~1.5.19"
+      },
+      "devDependencies": {
+        "@types/google_interactive_media_ads_types": "^1.20241219.0",
+        "esbuild": "^0.24.1",
+        "npm-run-all": "^4.1.5",
+        "typescript": "^5.8.2"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@mux/mux-video": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.24.3.tgz",
+      "integrity": "sha512-HM5oasXfmYVfmsTMv1lZIW/OkHEQMJwavrl1gI4p13bdlmmUu2CNARiTv/tYATJ9+NkYHlU3RsteHXx7tK7+vg==",
+      "dependencies": {
+        "@mux/playback-core": "0.28.3",
+        "castable-video": "~1.1.4",
+        "custom-media-element": "~1.4.2",
+        "media-tracks": "~0.3.2"
+      }
+    },
+    "packages/mux-video-ads/node_modules/@mux/playback-core": {
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.28.3.tgz",
+      "integrity": "sha512-QID2zp76szCTiXZp5LLYwDZV68HgflOoF10Vmp6P81FqKHonHVrQ0svNGqW6fMZLH2Ymf/Qc6kHSnwWTucgQqA==",
+      "dependencies": {
+        "hls.js": "~1.5.19",
+        "mux-embed": "^5.5.0"
+      }
+    },
+    "packages/mux-video-ads/node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "packages/mux-video-react": {

--- a/packages/mux-video-ads/package.json
+++ b/packages/mux-video-ads/package.json
@@ -74,6 +74,6 @@
     "hls.js": "~1.5.19",
     "@mux/mux-video": "0.24.4",
     "@mux/playback-core": "0.28.4",
-    "@mux/mux-data-google-ima": "0.2.7"
+    "@mux/mux-data-google-ima": "0.2.8"
   }
 }

--- a/packages/mux-video-ads/package.json
+++ b/packages/mux-video-ads/package.json
@@ -72,6 +72,8 @@
   },
   "dependencies": {
     "hls.js": "~1.5.19",
-    "@mux/mux-video": "0.24.3"
+    "@mux/mux-video": "0.24.4",
+    "@mux/playback-core": "0.28.4",
+    "@mux/mux-data-google-ima": "0.2.7"
   }
 }

--- a/packages/mux-video-ads/src/ads-manager.ts
+++ b/packages/mux-video-ads/src/ads-manager.ts
@@ -1,6 +1,7 @@
 /// <reference types="google_interactive_media_ads_types" />
 
 import MuxVideoElement from '@mux/mux-video';
+import { Hls } from '@mux/playback-core';
 
 export type MuxAdManagerConfig = {
   videoElement: MuxVideoElement;
@@ -80,6 +81,7 @@ export class MuxAdManager {
       if (this.isIOSMse(this.#customMediaElement.src)) {
         if (this.#customMediaElement._hls) {
           console.log('Disconnecting Hls for iOS');
+          // this.#customMediaElement.mux?.removeHLSJS();
           this.#customMediaElement._hls.detachMedia();
           this.#customMediaElement._hls.stopLoad();
           this.#videoElement.removeAttribute('src');
@@ -101,6 +103,10 @@ export class MuxAdManager {
 
           if (this.#customMediaElement._hls) {
             this.#customMediaElement._hls.attachMedia(this.#videoElement);
+            // this.#customMediaElement.mux?.addHLSJS({
+            //   hlsjs: this.#customMediaElement._hls,
+            //   Hls: this.#customMediaElement._hls ? Hls : undefined,
+            // });
             this.#customMediaElement._hls.loadSource(this.#videoBackup.originalSrc);
             this.#customMediaElement._hls.startLoad(this.#videoBackup.contentTime);
           }
@@ -295,5 +301,9 @@ export class MuxAdManager {
 
   updateViewMode(isFullscreen: boolean) {
     this.#viewMode = isFullscreen ? google.ima.ViewMode.FULLSCREEN : google.ima.ViewMode.NORMAL;
+  }
+
+  get adsLoader() {
+    return this.#adsLoader;
   }
 }

--- a/packages/mux-video-ads/src/index.ts
+++ b/packages/mux-video-ads/src/index.ts
@@ -1,5 +1,11 @@
+/* eslint @typescript-eslint/triple-slash-reference: "off" */
+/// <reference path="../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" preserve="true" />
 import MuxVideoElement from '@mux/mux-video';
+/** @TODO publish types for package to use here (CJP) */
+// @ts-ignore
+import mux from '@mux/mux-data-google-ima';
 import { MuxAdManagerConfig, MuxAdManager } from './ads-manager';
+import type { MuxDataSDK } from '@mux/playback-core';
 
 const serializeAttributes = (attrs = {}) => {
   return (
@@ -290,6 +296,16 @@ video::-webkit-media-text-track-container {
   set mediaIsFullscreen(val: boolean) {
     if (val === this.mediaIsFullscreen) return;
     this.#mediaIsFullscreen = val;
+  }
+
+  get muxDataSDK() {
+    return mux as MuxDataSDK;
+  }
+
+  get muxDataSDKOptions() {
+    return {
+      imaAdsLoader: this.#muxAdManager?.adsLoader,
+    };
   }
 }
 

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -963,12 +963,14 @@ export const setupMux = (
       | 'customDomain'
       | 'disableCookies'
       | 'disableTracking'
+      | 'muxDataSDK'
+      | 'muxDataSDKOptions'
     >
   >,
   mediaEl: HTMLMediaElement,
   hlsjs?: HlsInterface
 ) => {
-  const { envKey: env_key, disableTracking } = props;
+  const { envKey: env_key, disableTracking, muxDataSDK = mux, muxDataSDKOptions = {} } = props;
   const inferredEnv = isMuxVideoSrc(props);
 
   if (!disableTracking && (env_key || inferredEnv)) {
@@ -998,7 +1000,7 @@ export const setupMux = (
       return error;
     };
 
-    mux.monitor(mediaEl, {
+    muxDataSDK.monitor(mediaEl, {
       debug,
       beaconCollectionDomain,
       hlsjs,
@@ -1006,6 +1008,7 @@ export const setupMux = (
       automaticErrorTracking: false,
       errorTranslator: muxEmbedErrorTranslator,
       disableCookies,
+      ...muxDataSDKOptions,
       data: {
         ...(env_key ? { env_key } : {}),
         // Metadata fields

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/triple-slash-reference: "off" */
 /// <reference path="../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" preserve="true" />
-import type { Options } from 'mux-embed';
+import type { Options, Mux } from 'mux-embed';
 import type { MediaError } from './errors';
 import type { HlsConfig } from 'hls.js';
 import type Hls from 'hls.js';
@@ -21,9 +21,11 @@ export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Required<Options>['data']>;
 type MetaData = Metadata;
 export type PlaybackEngine = Hls;
+export type MuxDataSDK = Mux;
 
 export type PlaybackCore = {
   engine?: PlaybackEngine;
+  muxDataSDK?: MuxDataSDK;
   setAutoplay: (autoplay?: Autoplay) => void;
   setPreload: (preload?: HTMLMediaElement['preload']) => void;
 };
@@ -201,5 +203,7 @@ export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
 export type MuxMediaPropsInternal = MuxMediaProps & {
   playerSoftwareName: MetaData['player_software_name'];
   playerSoftwareVersion: MetaData['player_software_version'];
+  muxDataSDK?: Mux;
+  muxDataSDKOptions?: Mux;
   drmTypeCb?: (drmType: Metadata['view_drm_type']) => void;
 };


### PR DESCRIPTION
- Updates the one off mux-video-ads package impl to use the google-ima extension of mux-embed (mux data sdk)
- Commented out expected requirement to add/remove hlsjs from mux data monitor if/when it has to be destroyed recreated (e.g. for Mobile Safari + MSE)
- Updated example to make testing easier (can comment out/swap with whatever helps particular test cases for now) 