### PR TITLE
fix: init & teardown hls.js separately for iOS ads 

### DIFF
--- a/examples/nextjs-with-typescript/pages/mux-video-ads-react.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-video-ads-react.tsx
@@ -52,10 +52,11 @@ function MuxVideoPage() {
         controls
         autoplay={autoplay}
         muted={muted}
+        playsInline={true}
         maxResolution="2160p"
         minResolution="540p"
         renditionOrder="desc"
-        preferPlayback="native"
+        preferPlayback="mse"
         adTagUrl="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="
         onPlay={() => {
           setPaused(false);

--- a/packages/mux-video-ads/src/ads-manager.ts
+++ b/packages/mux-video-ads/src/ads-manager.ts
@@ -79,15 +79,8 @@ export class MuxAdManager {
       };
 
       if (this.isIOSMse(this.#customMediaElement.src)) {
-        if (this.#customMediaElement._hls) {
-          console.log('Disconnecting Hls for iOS');
-          // this.#customMediaElement.mux?.removeHLSJS();
-          this.#customMediaElement._hls.detachMedia();
-          this.#customMediaElement._hls.stopLoad();
-          this.#videoElement.removeAttribute('src');
-          this.#videoElement.load();
-        }
-        this.#customMediaElement.src = '';
+        // this.#customMediaElement.src = '';
+        this.#customMediaElement._teardownHls();
       } else {
         // Non-iOS handling
         console.log('Standard content pause for non-iOS');
@@ -99,17 +92,8 @@ export class MuxAdManager {
       google.ima.AdEvent.Type.CONTENT_RESUME_REQUESTED,
       () => {
         if (this.#videoBackup && this.isIOSMse(this.#videoBackup.originalSrc)) {
-          this.#customMediaElement.src = this.#videoBackup.originalSrc;
-
-          if (this.#customMediaElement._hls) {
-            this.#customMediaElement._hls.attachMedia(this.#videoElement);
-            // this.#customMediaElement.mux?.addHLSJS({
-            //   hlsjs: this.#customMediaElement._hls,
-            //   Hls: this.#customMediaElement._hls ? Hls : undefined,
-            // });
-            this.#customMediaElement._hls.loadSource(this.#videoBackup.originalSrc);
-            this.#customMediaElement._hls.startLoad(this.#videoBackup.contentTime);
-          }
+          // this.#customMediaElement.src = this.#videoBackup.originalSrc;
+          this.#customMediaElement._initializeHls();
 
           // Restore content position
           if (this.#videoBackup?.contentTime) {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -2,6 +2,8 @@ import { globalThis } from './polyfills';
 import {
   initialize,
   teardown,
+  initializeHls,
+  teardownHls,
   generatePlayerInitTime,
   MuxMediaProps,
   StreamTypes,
@@ -718,6 +720,14 @@ class MuxVideoBaseElement extends CustomVideoElement implements Partial<MuxMedia
   unload() {
     teardown(this.nativeEl, this.#core);
     this.#core = undefined;
+  }
+
+  _initializeHls() {
+    this.#core = initializeHls(this as Partial<MuxMediaProps>, this.nativeEl);
+  }
+
+  _teardownHls() {
+    teardownHls(this.nativeEl, this.#core);
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {


### PR DESCRIPTION
this change adds separate methods for init and teardown of hls.js so Mux data doesn't end the view / session.

destroying hls.js is needed for the ad because the ad uses native hls playback on iOS and the re-used video element has to be cleared of MSE related stuff.