### PR TITLE
Fix playback issues (events, native iOS)

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayerAds.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerAds.tsx
@@ -59,12 +59,12 @@ function MuxPlayerAdsPage() {
 
       {sdkLoaded && <MuxPlayer
         ref={mediaElRef}
-        playbackId="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+        playbackId="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
         theme="newsweek-theme"
         themeProps={{ controlBarVertical: true, controlBarPlace: 'start start' }}
         metadata={{
           video_id: "video-id-12345",
-          video_title: "Mad Max: Fury Road Trailer",
+          video_title: "Elephants Dream",
           viewer_user_id: "user-id-6789",
         }}
         streamType="on-demand"

--- a/examples/vanilla-ts-esm/public/mux-player-ads.html
+++ b/examples/vanilla-ts-esm/public/mux-player-ads.html
@@ -44,7 +44,7 @@
 
     <mux-player
       stream-type="on-demand"
-      playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+      playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
       mux-video-element="mux-video-ads"
       adTagUrl="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="
     ></mux-player>

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -277,6 +277,7 @@ const MuxPlayer = React.forwardRef<
     <MuxPlayerInternal
       /** @TODO Fix types relationships (CJP) */
       ref={playerRef as typeof innerPlayerRef}
+      muxVideoElement={props.muxVideoElement}
       playerSoftwareName={playerSoftwareName}
       playerSoftwareVersion={playerSoftwareVersion}
       playerInitTime={playerInitTime}

--- a/packages/mux-video-ads/src/ads-manager.ts
+++ b/packages/mux-video-ads/src/ads-manager.ts
@@ -90,7 +90,7 @@ export class MuxAdManager {
         if (this.isMSE()) {
           console.log('MSE pause');
           this.#customMediaElement._teardownHls();
-        } else if (this.isNative()) {
+        } else {
           console.log('Native pause');
           this.#customMediaElement.src = '';
           this.#customMediaElement.load();
@@ -108,7 +108,7 @@ export class MuxAdManager {
           if (this.isMSE()) {
             console.log('MSE Resume');
             this.#customMediaElement._initializeHls();
-          } else if (this.isNative()) {
+          } else {
             console.log('Native Resume');
             this.#customMediaElement.src = this.#videoBackup.originalSrc;
           }
@@ -288,11 +288,7 @@ export class MuxAdManager {
   }
 
   isMSE(): boolean {
-    return this.#customMediaElement.getAttribute('prefer-playback') === 'mse';
-  }
-
-  isNative(): boolean {
-    return this.#customMediaElement.getAttribute('prefer-playback') === 'native';
+    return !!this.#customMediaElement._hls;
   }
 
   updateViewMode(isFullscreen: boolean) {

--- a/packages/mux-video-ads/src/ads-manager.ts
+++ b/packages/mux-video-ads/src/ads-manager.ts
@@ -1,10 +1,10 @@
 /* eslint @typescript-eslint/triple-slash-reference: "off" */
 /// <reference types="google_interactive_media_ads_types" preserve="true"/>
 
-import MuxVideoElement from '@mux/mux-video';
+import MuxVideoAdsElement from './index.js';
 
 export type MuxAdManagerConfig = {
-  videoElement: MuxVideoElement;
+  videoElement: MuxVideoAdsElement;
   contentVideoElement: HTMLVideoElement;
   originalSize: DOMRect;
   adContainer: HTMLElement;
@@ -24,7 +24,7 @@ export class MuxAdManager {
   #adProgressData: google.ima.AdProgressData | undefined | null;
   #adPaused = false;
   #videoElement: HTMLVideoElement;
-  #customMediaElement: MuxVideoElement;
+  #customMediaElement: MuxVideoAdsElement;
   #viewMode: google.ima.ViewMode;
   #videoBackup: VideoBackup | null = null;
   #originalSize: DOMRect;
@@ -87,14 +87,9 @@ export class MuxAdManager {
       };
 
       if (this.isUsingSameVideoElement()) {
-        if (this.isMSE()) {
-          console.log('MSE pause');
-          this.#customMediaElement._teardownHls();
-        } else {
-          console.log('Native pause');
-          this.#customMediaElement.src = '';
-          this.#customMediaElement.load();
-        }
+        this.#customMediaElement.muxDataKeepSession = true;
+        this.#customMediaElement.unload();
+        this.#customMediaElement.muxDataKeepSession = false;
       } else {
         this.#videoElement.style.display = 'none';
       }
@@ -105,13 +100,9 @@ export class MuxAdManager {
       () => {
         console.log('CONTENT_RESUME_REQUESTED');
         if (this.#videoBackup && this.isUsingSameVideoElement()) {
-          if (this.isMSE()) {
-            console.log('MSE Resume');
-            this.#customMediaElement._initializeHls();
-          } else {
-            console.log('Native Resume');
-            this.#customMediaElement.src = this.#videoBackup.originalSrc;
-          }
+          this.#customMediaElement.muxDataKeepSession = true;
+          this.#customMediaElement.load();
+          this.#customMediaElement.muxDataKeepSession = false;
 
           // Restore content position
           if (this.#videoBackup?.contentTime) {
@@ -285,10 +276,6 @@ export class MuxAdManager {
     const videoElements = this.#adContainer.querySelectorAll('video');
     console.log('videoElements', videoElements.length, videoElements);
     return videoElements.length === 0;
-  }
-
-  isMSE(): boolean {
-    return !!this.#customMediaElement._hls;
   }
 
   updateViewMode(isFullscreen: boolean) {

--- a/packages/mux-video-ads/src/index.ts
+++ b/packages/mux-video-ads/src/index.ts
@@ -358,6 +358,14 @@ video::-webkit-media-text-track-container {
       imaAdsLoader: this.#muxAdManager?.adsLoader,
     };
   }
+
+  set muxDataKeepSession(val: boolean) {
+    this.toggleAttribute('mux-data-keep-session', Boolean(val));
+  }
+
+  get muxDataKeepSession(): boolean {
+    return this.hasAttribute('mux-data-keep-session');
+  }
 }
 
 type MuxVideoAdsElementType = typeof MuxVideoAds;

--- a/packages/mux-video-ads/src/index.ts
+++ b/packages/mux-video-ads/src/index.ts
@@ -231,19 +231,12 @@ video::-webkit-media-text-track-container {
   }
 
   onEnded() {
-    //TODO: this is a hack to prevent the play event from being called twice but we are able to propagate the event to the parent
-    this.dispatchEvent(new CustomEvent('ended', { composed: true, bubbles: true }));
     if (this.adTagUrl && this.#muxAdManager?.isReadyForComplete()) {
       this.#muxAdManager.contentComplete();
     }
   }
 
   play() {
-    //TODO: this is a hack to prevent the play event from being called twice but we are able to propagate the event to the parent
-    this.removeEventListener('play', this.play);
-    this.dispatchEvent(new CustomEvent('play', { composed: true, bubbles: true }));
-    this.addEventListener('play', this.play);
-
     if (this.adTagUrl && this.adBreak) {
       if (this.#muxAdManager?.isAdPaused()) {
         this.#muxAdManager?.resumeAdManager();
@@ -274,11 +267,6 @@ video::-webkit-media-text-track-container {
   }
 
   pause(): void {
-    //TODO: this is a hack to prevent the play event from being called twice but we are able to propagate the event to the parent
-    this.removeEventListener('pause', this.pause);
-    this.dispatchEvent(new CustomEvent('pause', { composed: true, bubbles: true }));
-    this.addEventListener('pause', this.pause);
-
     if (this.adBreak) {
       this.#muxAdManager?.pauseAdManager();
     }

--- a/packages/mux-video-ads/src/index.ts
+++ b/packages/mux-video-ads/src/index.ts
@@ -5,7 +5,7 @@ import MuxVideoElement from '@mux/mux-video';
 // @ts-ignore
 import mux from '@mux/mux-data-google-ima';
 import { MuxAdManagerConfig, MuxAdManager } from './ads-manager';
-// import type { MuxDataSDK } from '@mux/playback-core';
+import type { MuxDataSDK } from '@mux/playback-core';
 
 const serializeAttributes = (attrs = {}) => {
   return (
@@ -349,9 +349,9 @@ video::-webkit-media-text-track-container {
     return super.requestPictureInPicture();
   }
 
-  // get muxDataSDK() {
-  //   return mux as MuxDataSDK;
-  // }
+  get muxDataSDK() {
+    return mux as MuxDataSDK;
+  }
 
   get muxDataSDKOptions() {
     return {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -2,8 +2,6 @@ import { globalThis } from './polyfills';
 import {
   initialize,
   teardown,
-  initializeHls,
-  teardownHls,
   generatePlayerInitTime,
   MuxMediaProps,
   StreamTypes,
@@ -718,16 +716,8 @@ class MuxVideoBaseElement extends CustomVideoElement implements Partial<MuxMedia
   }
 
   unload() {
-    teardown(this.nativeEl, this.#core);
+    teardown(this.nativeEl, this.#core, this as Partial<MuxMediaProps>);
     this.#core = undefined;
-  }
-
-  _initializeHls() {
-    this.#core = initializeHls(this as Partial<MuxMediaProps>, this.nativeEl);
-  }
-
-  _teardownHls() {
-    teardownHls(this.nativeEl, this.#core);
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -508,7 +508,7 @@ export const getEnded = (
 
 export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLMediaElement, core?: PlaybackCore) => {
   // Automatically tear down previously initialized mux data & hls instance if it exists.
-  teardown(mediaEl, core);
+  teardown(mediaEl, core, props);
   // NOTE: metadata should never be nullish/nil. Adding here for type safety due to current type defs.
   const { metadata = {} } = props;
   const { view_session_id = generateUUID() } = metadata;
@@ -527,7 +527,18 @@ export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLM
   muxMediaState.set(mediaEl as HTMLMediaElement, {});
   const nextHlsInstance = setupHls(props, mediaEl);
   const setPreload = setupPreload(props as Pick<MuxMediaProps, 'preload' | 'src'>, mediaEl, nextHlsInstance);
-  setupMux(props, mediaEl, nextHlsInstance);
+
+  if (props?.muxDataKeepSession && mediaEl?.mux && !mediaEl.mux.deleted) {
+    if (nextHlsInstance) {
+      mediaEl.mux.addHLSJS({
+        hlsjs: nextHlsInstance as HlsInterface,
+        Hls: nextHlsInstance ? Hls : undefined,
+      });
+    }
+  } else {
+    setupMux(props, mediaEl, nextHlsInstance);
+  }
+
   loadMedia(props, mediaEl, nextHlsInstance);
   setupCuePoints(mediaEl);
   setupChapters(mediaEl);
@@ -540,63 +551,32 @@ export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLM
   };
 };
 
-export const teardown = (mediaEl?: HTMLMediaElement | null, core?: PlaybackCore) => {
+export const teardown = (
+  mediaEl?: HTMLMediaElement | null,
+  core?: PlaybackCore,
+  props?: Partial<MuxMediaPropsInternal>
+) => {
   const hls = core?.engine;
+
+  if (mediaEl?.mux && !mediaEl.mux.deleted) {
+    if (props?.muxDataKeepSession) {
+      if (hls) mediaEl.mux.removeHLSJS();
+    } else {
+      mediaEl.mux.destroy();
+      delete mediaEl.mux;
+    }
+  }
+
   if (hls) {
     hls.detachMedia();
     hls.destroy();
   }
-  if (mediaEl?.mux && !mediaEl.mux.deleted) {
-    mediaEl.mux.destroy();
-    delete mediaEl.mux;
-  }
+
   if (mediaEl) {
-    mediaEl.removeAttribute('src');
-    mediaEl.load();
-    mediaEl.removeEventListener('error', handleNativeError);
-    mediaEl.removeEventListener('error', handleInternalError);
-    mediaEl.removeEventListener('durationchange', seekInSeekableRange);
-    muxMediaState.delete(mediaEl);
-    mediaEl.dispatchEvent(new Event('teardown'));
-  }
-};
-
-export const initializeHls = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLMediaElement) => {
-  const nextHlsInstance = setupHls(props, mediaEl);
-  const setPreload = setupPreload(props as Pick<MuxMediaProps, 'preload' | 'src'>, mediaEl, nextHlsInstance);
-
-  if (mediaEl?.mux && !mediaEl.mux.deleted) {
-    mediaEl.mux.addHLSJS({
-      hlsjs: nextHlsInstance as HlsInterface,
-      Hls: nextHlsInstance ? Hls : undefined,
-    });
-  }
-
-  loadMedia(props, mediaEl, nextHlsInstance);
-  setupCuePoints(mediaEl);
-  setupChapters(mediaEl);
-
-  const setAutoplay = setupAutoplay(props as Pick<MuxMediaProps, 'autoplay'>, mediaEl, nextHlsInstance);
-
-  return {
-    engine: nextHlsInstance,
-    setPreload,
-    setAutoplay,
-  };
-};
-
-export const teardownHls = (mediaEl: HTMLMediaElement, core?: PlaybackCore) => {
-  if (mediaEl?.mux && !mediaEl.mux.deleted) {
-    mediaEl.mux.removeHLSJS();
-  }
-  const hls = core?.engine;
-  if (hls) {
-    hls.detachMedia();
-    hls.destroy();
-  }
-  if (mediaEl) {
-    mediaEl.removeAttribute('src');
-    mediaEl.load();
+    if (mediaEl.hasAttribute('src')) {
+      mediaEl.removeAttribute('src');
+      mediaEl.load();
+    }
     mediaEl.removeEventListener('error', handleNativeError);
     mediaEl.removeEventListener('error', handleInternalError);
     mediaEl.removeEventListener('durationchange', seekInSeekableRange);

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -205,5 +205,6 @@ export type MuxMediaPropsInternal = MuxMediaProps & {
   playerSoftwareVersion: MetaData['player_software_version'];
   muxDataSDK?: Mux;
   muxDataSDKOptions?: Mux;
+  muxDataKeepSession?: boolean;
   drmTypeCb?: (drmType: Metadata['view_drm_type']) => void;
 };


### PR DESCRIPTION
- [x] fix mux-video-ads setup in init / events issue
- [x] fix MSE / native check
- [x] fix native iOS Mux data session issue

@ismapin22 we can't check the playback type mse / native just by attributes. internally in playback-core there is more logic behind that decision, plus if no attribute is set the default is prefer native for iOS which the attribute check also missed. easiest is to check against the `._hls` prop if MSE is used or not..
